### PR TITLE
Update NanoObjects.py

### DIFF
--- a/ScatterSim/NanoObjects.py
+++ b/ScatterSim/NanoObjects.py
@@ -1268,14 +1268,16 @@ class SphereNanoObject(NanoObject):
     def form_factor_isotropic(self, q, num_phi=50, num_theta=50):
         """Returns the particle form factor, averaged over every possible orientation.
         """
-        return self.form_factor(np.array([q, 0, 0]))
+        #return self.form_factor(np.array([q, 0, 0]))
+        return self.form_factor(np.array([q, np.zeros(len(q)), np.zeros(len(q))]))
 
     def form_factor_squared_isotropic(self, q, num_phi=50, num_theta=50):
         """Returns the particle form factor squared, averaged over every
         possible orientation.
         """
         # numpy should broadcast 0 to same length as q
-        return self.form_factor_squared(np.array([q, 0, 0]))
+        #return self.form_factor_squared(np.array([q, 0, 0]))
+        return self.form_factor_squared(np.array([q, np.zeros(len(q)), np.zeros(len(q))]))
 
     def to_string(self):
         """Returns a string describing the object."""


### PR DESCRIPTION
The following line has a problem with the new Numpy.

np.array([q, 0, 0])

q is a 1D array, 0 is a number, and the new version of numpy will NOT broadcast 0 as 1D array anymore. There will be an error message.

Change to the following

np.array([q, np.zeros(len(q)), np.zeros(len(q))]))

to create a correct 2D array.